### PR TITLE
fix(#492): use onApplicationShutdown instead of onModuleDestroy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ typings/
 dist
 .idea
 .DS_Store
+.turbo

--- a/packages/redlock/src/redlock.module.ts
+++ b/packages/redlock/src/redlock.module.ts
@@ -1,4 +1,4 @@
-import { Inject, Module, OnModuleDestroy } from "@nestjs/common";
+import { Inject, Module, OnApplicationShutdown } from "@nestjs/common";
 import { RedlockModuleOptions } from "./redlock.interface";
 import { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } from "./redlock.module-definition";
 import { RedlockService } from "./redlock.service";
@@ -13,12 +13,12 @@ import { RedlockService } from "./redlock.service";
   ],
   exports: [RedlockService],
 })
-export class RedlockModule extends ConfigurableModuleClass implements OnModuleDestroy {
+export class RedlockModule extends ConfigurableModuleClass implements OnApplicationShutdown {
   constructor(@Inject(MODULE_OPTIONS_TOKEN) private readonly options: RedlockModuleOptions) {
     super();
   }
 
-  public async onModuleDestroy(): Promise<void> {
+  public async onApplicationShutdown(): Promise<void> {
     for (const client of this.options.clients) {
       switch (client.status) {
         case "end":

--- a/packages/simple-redlock/src/redlock.module.ts
+++ b/packages/simple-redlock/src/redlock.module.ts
@@ -1,4 +1,4 @@
-import { Inject, Module, OnModuleDestroy } from "@nestjs/common";
+import { Inject, Module, OnApplicationShutdown } from "@nestjs/common";
 import { SimpleRedlockModuleOptions } from "./redlock.interface";
 import { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } from "./redlock.module-definition";
 import { SimpleRedlockService } from "./redlock.service";
@@ -13,12 +13,12 @@ import { SimpleRedlockService } from "./redlock.service";
   ],
   exports: [SimpleRedlockService],
 })
-export class SimpleRedlockModule extends ConfigurableModuleClass implements OnModuleDestroy {
+export class SimpleRedlockModule extends ConfigurableModuleClass implements OnApplicationShutdown {
   constructor(@Inject(MODULE_OPTIONS_TOKEN) private readonly options: SimpleRedlockModuleOptions) {
     super();
   }
 
-  public async onModuleDestroy(): Promise<void> {
+  public async onApplicationShutdown(): Promise<void> {
     switch (this.options.client.status) {
       case "end":
         break;


### PR DESCRIPTION
The connection may need to remain alive even when the module is destroyed. Change to affect only shutdown.