### PR TITLE
feat: switch from abandoned redlock library to @sesamecare-oss/redlock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1250,8 +1250,7 @@
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-      "dev": true
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3159,6 +3158,18 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true
     },
+    "node_modules/@sesamecare-oss/redlock": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@sesamecare-oss/redlock/-/redlock-1.3.1.tgz",
+      "integrity": "sha512-HXpio3BlhMsAhhIVKASARmnLDXEpBtjQsys28Nka5QtmhDqf+TGmWjObCQ2u3MeKo6/6O9cfghSHBir0YRDQXQ==",
+      "license": "UNLICENSED",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "ioredis": ">=5"
+      }
+    },
     "node_modules/@sigstore/bundle": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.2.0.tgz",
@@ -4623,7 +4634,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5198,7 +5208,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
       "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -5293,7 +5302,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6992,7 +7000,6 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
       "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
-      "dev": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -9323,14 +9330,12 @@
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "dev": true
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9910,8 +9915,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multer": {
       "version": "1.4.4-lts.1",
@@ -10000,11 +10004,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -11132,7 +11131,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11141,23 +11139,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "dev": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/redlock": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/redlock/-/redlock-5.0.0-beta.2.tgz",
-      "integrity": "sha512-2RDWXg5jgRptDrB1w9O/JgSZC0j7y4SlaXnor93H/UJm/QyDiFgBKNtrh0TI6oCXqYSaSoXxFh6Sd3VtYfhRXw==",
-      "dependencies": {
-        "node-abort-controller": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/reflect-metadata": {
@@ -11760,8 +11746,7 @@
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "dev": true
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -13100,7 +13085,7 @@
       "version": "0.2.44",
       "license": "MIT",
       "dependencies": {
-        "redlock": "^5.0.0-beta.2"
+        "@sesamecare-oss/redlock": "^1.3.1"
       },
       "devDependencies": {
         "@nestjs/common": "10.4.4",

--- a/packages/redlock/package.json
+++ b/packages/redlock/package.json
@@ -25,7 +25,7 @@
     "watch": "tsc --watch"
   },
   "dependencies": {
-    "redlock": "^5.0.0-beta.2"
+    "@sesamecare-oss/redlock": "^1.3.1"
   },
   "devDependencies": {
     "@nestjs/common": "10.4.4",

--- a/packages/redlock/src/redlock.decorator.ts
+++ b/packages/redlock/src/redlock.decorator.ts
@@ -1,5 +1,5 @@
 import { Inject } from "@nestjs/common";
-import { RedlockAbortSignal, Settings } from "redlock";
+import { RedlockAbortSignal, Settings } from "@sesamecare-oss/redlock";
 import { DEFAULT_DURATION } from "./redlock.constants";
 import { RedlockKeyFunction } from "./redlock.interface";
 import { RedlockService } from "./redlock.service";

--- a/packages/redlock/src/redlock.fake-service.ts
+++ b/packages/redlock/src/redlock.fake-service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { EventEmitter } from "events";
-import { ExecutionResult, Lock, RedlockAbortSignal, Settings } from "redlock";
+import { ExecutionResult, Lock, RedlockAbortSignal, Settings } from "@sesamecare-oss/redlock";
 
 export class FakeRedlockService extends EventEmitter {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -11,7 +11,7 @@ export class FakeRedlockService extends EventEmitter {
   }
 
   public async release(lock: Lock, settings?: Partial<Settings> | undefined): Promise<ExecutionResult> {
-    return { attempts: [] };
+    return { attempts: [], start: Date.now() };
   }
 
   public async extend(existing: Lock, duration: number, settings?: Partial<Settings> | undefined): Promise<Lock> {
@@ -47,7 +47,7 @@ function createLockFake(): Lock {
 
   // eslint-disable-next-line prefer-const
   lock = {
-    release: async (): Promise<ExecutionResult> => ({ attempts: [] }),
+    release: async (): Promise<ExecutionResult> => ({ attempts: [], start: Date.now() }),
     extend: async (duration: number): Promise<Lock> => lock,
   } as Lock;
 

--- a/packages/redlock/src/redlock.interface.ts
+++ b/packages/redlock/src/redlock.interface.ts
@@ -1,5 +1,5 @@
 import Redis, { Cluster } from "ioredis";
-import { Settings } from "redlock";
+import { Settings } from "@sesamecare-oss/redlock";
 
 export type PreLockedKeysHookArgs = { keys: string[]; duration: number };
 export type LockedKeysHookArgs = { keys: string[]; duration: number; elapsedTime: number };
@@ -15,11 +15,6 @@ export type RedlockModuleOptions = {
   decoratorEnabled?: boolean;
 
   settings?: Partial<Settings>;
-  scripts?: {
-    readonly acquireScript?: string | ((script: string) => string);
-    readonly extendScript?: string | ((script: string) => string);
-    readonly releaseScript?: string | ((script: string) => string);
-  };
   /**
    * Hooks called when using @Redlock decorator.
    */

--- a/packages/redlock/src/redlock.service.ts
+++ b/packages/redlock/src/redlock.service.ts
@@ -1,11 +1,11 @@
 import { Inject, Injectable } from "@nestjs/common";
-import Redlock from "redlock";
+import { Redlock } from "@sesamecare-oss/redlock";
 import { RedlockModuleOptions } from "./redlock.interface";
 import { MODULE_OPTIONS_TOKEN } from "./redlock.module-definition";
 
 @Injectable()
 export class RedlockService extends Redlock {
   constructor(@Inject(MODULE_OPTIONS_TOKEN) public readonly options: RedlockModuleOptions) {
-    super(options.clients, options.settings, options.scripts);
+    super(options.clients, options.settings);
   }
 }


### PR DESCRIPTION
Hi, first of all, thanks for this module.

The original [node-redlock](https://github.com/mike-marcacci/node-redlock) library seems to be abandoned and in a broken state. I've created this pull request so you can switch to an alternative [@sesamecare-oss/redlock](https://github.com/sesamecare/redlock).

Here's some background of the issues that made me create this PR:
- https://github.com/mike-marcacci/node-redlock/issues/160
- https://github.com/mike-marcacci/node-redlock/issues/290
- https://github.com/mike-marcacci/node-redlock/issues/173

In short, the original redlock library, as of the v5 release cannot be used in any modern NodeJS project, because of the Node16/NodeNext module resolution. This is already fixed upstream but never made it to the release and it doesn't look like it will happen anytime soon.

There's only one drawback of this PR i know of - loosing the ability to provide custom acquire/extend/release scripts, but IMHO this is unlikely critical for this library.